### PR TITLE
Loyalty implant

### DIFF
--- a/Content.Server/_Viva/LoyaltyImplant/LoyaltyImplantSystem.cs
+++ b/Content.Server/_Viva/LoyaltyImplant/LoyaltyImplantSystem.cs
@@ -1,0 +1,41 @@
+
+
+using Content.Server._Impstation.Thaven;
+using Content.Shared._Impstation.Thaven.Components;
+using Content.Shared.Dataset;
+using Content.Shared.Implants;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Toolshed.TypeParsers;
+
+namespace Content.Server._Viva.LoyaltyImplant;
+
+public sealed class LoyaltyImplantSysten : EntitySystem
+{
+    [Dependency] private readonly ThavenMoodsSystem _moodSystem = default!;
+
+    [ValidatePrototypeId<DatasetPrototype>]
+    private const string LoyaltyImplantMoods = "LoyaltyImplantMoods";
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<LoyaltyImplantComponent, ImplantImplantedEvent>(OnImplant);
+    }
+
+    private void OnImplant(EntityUid uid, LoyaltyImplantComponent component, ImplantImplantedEvent args)
+    {
+        if (args.Implanted == null)
+            return;
+
+         var target = args.Implanted.Value;
+
+        if (args.Implanted != null)
+        {
+            EnsureComp<ThavenMoodsComponent>(target, out var moodComp);
+            _moodSystem.ToggleEmaggable((target, moodComp));
+            _moodSystem.ClearMoods((target, moodComp));
+            _moodSystem.ToggleSharedMoods((target, moodComp));
+            _moodSystem.TryAddRandomMood((target, moodComp), LoyaltyImplantMoods);
+            Dirty(target, moodComp);
+        }
+    }
+}

--- a/Content.Server/_Viva/LoyaltyImplant/LoyaltyImplantSystem.cs
+++ b/Content.Server/_Viva/LoyaltyImplant/LoyaltyImplantSystem.cs
@@ -4,6 +4,7 @@ using Content.Server._Impstation.Thaven;
 using Content.Shared._Impstation.Thaven.Components;
 using Content.Shared.Dataset;
 using Content.Shared.Implants;
+using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed.TypeParsers;
 
@@ -19,6 +20,7 @@ public sealed class LoyaltyImplantSysten : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<LoyaltyImplantComponent, ImplantImplantedEvent>(OnImplant);
+        SubscribeLocalEvent<LoyaltyImplantComponent, EntGotRemovedFromContainerMessage>(OnRemove);
     }
 
     private void OnImplant(EntityUid uid, LoyaltyImplantComponent component, ImplantImplantedEvent args)
@@ -26,7 +28,8 @@ public sealed class LoyaltyImplantSysten : EntitySystem
         if (args.Implanted == null)
             return;
 
-         var target = args.Implanted.Value;
+        var target = args.Implanted.Value;
+        component.Target = target;
 
         if (args.Implanted != null)
         {
@@ -37,5 +40,13 @@ public sealed class LoyaltyImplantSysten : EntitySystem
             _moodSystem.TryAddRandomMood((target, moodComp), LoyaltyImplantMoods);
             Dirty(target, moodComp);
         }
+    }
+
+    private void OnRemove(EntityUid uid, LoyaltyImplantComponent component, EntGotRemovedFromContainerMessage args)
+    {
+        component.Target = args.Container.Owner;
+
+        if (HasComp<ThavenMoodsComponent>(args.Container.Owner))
+            RemComp<ThavenMoodsComponent>(args.Container.Owner);
     }
 }

--- a/Content.Shared/_Viva/LoyaltyImplant/LoyaltyImplantComponent.cs
+++ b/Content.Shared/_Viva/LoyaltyImplant/LoyaltyImplantComponent.cs
@@ -1,0 +1,10 @@
+
+
+using Robust.Shared.GameStates;
+
+namespace Content.Server._Viva.LoyaltyImplant;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class LoyaltyImplantComponent : Component
+{
+}

--- a/Content.Shared/_Viva/LoyaltyImplant/LoyaltyImplantComponent.cs
+++ b/Content.Shared/_Viva/LoyaltyImplant/LoyaltyImplantComponent.cs
@@ -7,4 +7,6 @@ namespace Content.Server._Viva.LoyaltyImplant;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class LoyaltyImplantComponent : Component
 {
+    [DataField]
+    public EntityUid? Target = null;
 }

--- a/Resources/Locale/en-US/_Viva/loyaltymood/moods.ftl
+++ b/Resources/Locale/en-US/_Viva/loyaltymood/moods.ftl
@@ -1,0 +1,8 @@
+thaven-mood-loyalty-implant-mood-name = Loyalty
+thaven-mood-loyalty-implant-mood-desc = You must follow all orders, to the word and spirit, from those higher ranked. You must work to increase nanotrasen profit. You wish to bring glory to Nanotrasen
+
+thaven-mood-flawed-loyalty-implant-mood-name = Flawed Loyalty
+thaven-mood-flawed-loyalty-implant-mood-desc = The implant didnt fully take. You must follow all orders from those of a higher rank to the letter. The spirit of the orders does not matter.
+
+thaven-mood-broken-loyalty-implant-mood-name = Broken Loyalty
+thaven-mood-broken-loyalty-implant-mood-desc = The implant didnt stick. Your free. Dont let them know that.

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -30,6 +30,7 @@
             - SubdermalImplant
       allowDeimplantAll: false
       deimplantWhitelist:
+      - LoyaltyImplant
       - SadTromboneImplant
       - LightImplant
       - BikeHornImplant

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -340,7 +340,7 @@
   parent: BaseSubdermalImplant
   id: MindShieldImplant
   name: mindshield implant
-  description: This implant will ensure loyalty to Nanotrasen and prevent mind control devices.
+  description: This implant will prevent mind control.
   categories: [ HideSpawnMenu ]
   components:
    - type: SubdermalImplant

--- a/Resources/Prototypes/_Viva/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/_Viva/Catalog/Cargo/cargo_security.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: SecurityArmor
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: icon
+  product: CrateSecurityLoyaltyImplants
+  cost: 4000
+  category: cargoproduct-category-name-security
+  group: market

--- a/Resources/Prototypes/_Viva/Catalog/Fills/Crates/security.yml
+++ b/Resources/Prototypes/_Viva/Catalog/Fills/Crates/security.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: CrateSecurityLoyaltyImplants
+  name: implanter crate
+  description: Contains 4 Loyalty Implanters.
+  parent: CrateSecgear
+  components:
+  - type: StorageFill
+    contents:
+      - id: LoyaltyImplanter
+        amount: 4

--- a/Resources/Prototypes/_Viva/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_Viva/Entities/Objects/Misc/implanters.yml
@@ -1,0 +1,7 @@
+- type: entity
+  id: LoyaltyImplanter
+  suffix: loyalty
+  parent: BaseImplantOnlyImplanter
+  components:
+    - type: Implanter
+      implant: LoyaltyImplant  

--- a/Resources/Prototypes/_Viva/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_Viva/Entities/Objects/Misc/subdermal_implants.yml
@@ -1,0 +1,9 @@
+- type: entity
+  parent: BaseSubdermalImplant
+  id: LoyaltyImplant
+  name: loyalty implant
+  description: This implant ensures loyalty to nanotrasen
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: SubdermalImplant
+    - type: LoyaltyImplant

--- a/Resources/Prototypes/_Viva/LoyaltyImplant/loyaltymood.yml
+++ b/Resources/Prototypes/_Viva/LoyaltyImplant/loyaltymood.yml
@@ -8,15 +8,15 @@
 
 - type: thavenMood
   id: LoyalLoyaltyImplantMood
-  moodName: Loyalty
-  moodDesc: You must follow all orders, to the word and intent, from those higher ranked. You must work to increase nanotrasen profit. You wish to bring glory to Nanotrasen
+  moodName: thaven-mood-loyalty-implant-mood-name
+  moodDesc: thaven-mood-loyalty-implant-mood-desc
 
 - type: thavenMood
   id: FlawedLoyaltyImplantMood
-  moodName: Flawed Loyalty
-  moodDesc: The implant didnt fully take. You must follow all orders from those of a higher rank to the letter. The orders intention does not matter.
+  moodName: thaven-mood-flawed-loyalty-implant-mood-name
+  moodDesc: thaven-mood-flawed-loyalty-implant-mood-desc
 
 - type: thavenMood
   id: BrokenLoyaltyImplantMood
-  moodName: Broken Loyalty
-  moodDesc: The implant didnt stick. Your free. Dont let them know that.
+  moodName: thaven-mood-broken-loyalty-implant-mood-name
+  moodDesc: thaven-mood-broken-loyalty-implant-mood-desc

--- a/Resources/Prototypes/_Viva/LoyaltyImplant/loyaltymood.yml
+++ b/Resources/Prototypes/_Viva/LoyaltyImplant/loyaltymood.yml
@@ -1,0 +1,22 @@
+- type: dataset
+  id: LoyaltyImplantMoods
+  values:
+    - LoyalLoyaltyImplantMood
+    - FlawedLoyaltyImplantMood
+    - BrokenLoyaltyImplantMood 
+
+
+- type: thavenMood
+  id: LoyalLoyaltyImplantMood
+  moodName: Loyalty
+  moodDesc: You must follow all orders, to the word and intent, from those higher ranked. You must work to increase nanotrasen profit. You wish to bring glory to Nanotrasen
+
+- type: thavenMood
+  id: FlawedLoyaltyImplantMood
+  moodName: Flawed Loyalty
+  moodDesc: The implant didnt fully take. You must follow all orders from those of a higher rank to the letter. The orders intention does not matter.
+
+- type: thavenMood
+  id: BrokenLoyaltyImplantMood
+  moodName: Broken Loyalty
+  moodDesc: The implant didnt stick. Your free. Dont let them know that.


### PR DESCRIPTION
Adds loyalty implants

when used, it adds one of three different thaven moods

One is the standard loyalty implant, which forces obedience

One is flawed, where the implanted has to follow the letter, but not the spirit, of the order

One is broken, where the implant fails to take entirely

They all have equal chances to activate

There is no current way to buy them, so whatever admin is on at the time will have to bluespace them in at command's request