### PR TITLE
Inital SoP and space law changes

### DIFF
--- a/Resources/Prototypes/Guidebook/security.yml
+++ b/Resources/Prototypes/Guidebook/security.yml
@@ -1,4 +1,4 @@
-﻿- type: guideEntry
+- type: guideEntry
   id: Security
   name: guide-entry-security
   text: "/ServerInfo/Guidebook/Security/Security.xml"
@@ -6,8 +6,8 @@
   - Forensics
   - Defusal
   - CriminalRecords
-  - RulesOfConduct # Funkystation
-  - SpaceLaw # Goobstation
+  - RulesOfConduct # Funkystation base, edited by Viva
+  - SpaceLaw # Goobstation base, edited by Viva
 
 - type: guideEntry
   id: Forensics

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -19,9 +19,6 @@
   - Detective
   - Cryogenics
   - External
-  special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
 
 - type: startingGear
   id: DetectiveGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -21,9 +21,6 @@
   - Service
   - External
   - Cryogenics
-  special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
 
 - type: startingGear
   id: SecurityCadetGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -18,9 +18,6 @@
   - Service
   - External
   - Cryogenics
-  special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
 
 - type: startingGear
   id: SecurityOfficerGear

--- a/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
+++ b/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
@@ -1,4 +1,4 @@
-﻿- type: guideEntry
+- type: guideEntry
   id: SOP101
   name: SOP 101
   text: "/ServerInfo/Funkystation/Guidebook/SOP/SOP101.xml"
@@ -13,6 +13,7 @@
   - AlertLevelsSOP
   - EnemiesOfTheCorporation
 
+  #Edited on Viva
 - type: guideEntry
   id: CommandSOP
   name: guide-entry-command-sop
@@ -31,6 +32,7 @@
   - DeltaAlertSOP
   - GammaAlertSOP
 
+#edited on viva
 - type: guideEntry
   id: SecuritySOP
   name: guide-entry-security-sop

--- a/Resources/ServerInfo/Funkystation/Guidebook/Command/CommandStandardOperatingProcedure.xml
+++ b/Resources/ServerInfo/Funkystation/Guidebook/Command/CommandStandardOperatingProcedure.xml
@@ -1,25 +1,21 @@
-﻿<Document>
+<Document>
   Here is a list of all the SOP documents for command.
 
   # Captain SOP
 
-  [bold]1.[/bold] The Captain is not permitted to perform regular Security Duty. However, they may still assist Security if they are understaffed, or if they see a crime being committed. However, the Captain is not permitted to take items from the Armory under normal circumstances, unless authorized by the Head of Security. In addition, the Captain may not requisition weaponry for themselves from Cargo and/or Science, unless there's an immediate threat to station and/or crew;
+  [bold]1.[/bold] If a Department lacks a Head of Staff, the Captain should make reasonable efforts to appoint an Acting Head of Staff, if there are available personnel to fill the position;
 
-  [bold]2.[/bold] If a Department lacks a Head of Staff, the Captain should make reasonable efforts to appoint an Acting Head of Staff, if there are available personnel to fill the position;
+  [bold]2.[/bold] The Captain is to ensure that Space Law is being correctly applied. This should be done in cooperation with the Head of Security;
 
-  [bold]3.[/bold] The Captain is to ensure that Space Law is being correctly applied. This should be done in cooperation with the Head of Security;
+  [bold]3.[/bold] The Captain is not to leave the Station unless given specific permission by Central Command, or it happens to be the end of the shift. To do so is to be considered abandoning their posts and is grounds for termination;
 
-  [bold]4.[/bold] The Captain is not to leave the Station unless given specific permission by Central Command, or it happens to be the end of the shift. To do so is to be considered abandoning their posts and is grounds for termination;
+  [bold]4.[/bold] The Captain must keep the Nuclear Authentication Disk on their person at all times or failing that, in the possession of the Head of Security or Blueshield;
 
-  [bold]5.[/bold] The Captain must keep the Nuclear Authentication Disk on their person at all times or failing that, in the possession of the Head of Security or Blueshield;
+  [bold]5.[/bold] The Captain, despite being in charge of the Station, is not separate from NanoTrasen. Any attempts to disregard general company policy are to be considered an instant condition for contract termination;
 
-  [bold]6.[/bold] The Captain is to attempt to resolve every issue that arises in Command locally before contacting Central Command;
+  [bold]6.[/bold] The Captain may only promote personnel to an Acting Head of Staff position if there is no assigned Head of Staff associated with the Department. The Acting Head of Staff must be a member of the Department they are to lead. See below for more information on Chain of Command;
 
-  [bold]7.[/bold] The Captain, despite being in charge of the Station, is not separate from NanoTrasen. Any attempts to disregard general company policy are to be considered an instant condition for contract termination;
-
-  [bold]8.[/bold] The Captain may only promote personnel to an Acting Head of Staff position if there is no assigned Head of Staff associated with the Department. The Acting Head of Staff must be a member of the Department they are to lead. See below for more information on Chain of Command;
-
-  [bold]9.[/bold] The Captain may not fire any Head of Staff without reasonable justification (ie, incompetency, criminal activity, or otherwise any action that endangers/compromises the station and/or crew). The Captain may not fire any Central Command VIPs (ie, Blueshield, NanoTrasen Representative) without permission from Central Command, unless they are blatantly acting against the well-being and safety of the crew and station. The Captain must also follow HoP SOP point 5.
+  [bold]7.[/bold] The Captain may not fire any Central Command VIPs (ie, Blueshield, NanoTrasen Representative) without permission from Central Command, unless they are blatantly acting against the well-being and safety of the crew and station. The Captain must also follow HoP SOP point 5.
 
   # Head of Personnel SOP
 
@@ -37,7 +33,7 @@
 
   [bold]7.[/bold] The Head of Personnel may not leave their office unmanned if there are personnel waiting in line. Failure to respond to personnel with a legitimate request within ten (10) minutes, either via radio or in person is to be considered a breach of Standard Operating Procedure;
 
-  [bold]8.[/bold] The Head of Personnel is not permitted to perform Security duty. The Head of Personnel is permitted to carry a Disabler for self-defense only.
+  [bold]8.[/bold] The Head of Personnel is not permitted to perform Security duty. However, the HoP is permitted to carry lethal weapons for self defense.
 
   # NanoTrasen Representative SOP
 
@@ -47,7 +43,7 @@
 
   [bold]3.[/bold] The NanoTrasen Representative must, together with the Head of Security, ensure that Space Law is being followed and correctly applied;
 
-  [bold]4.[/bold] The NanoTrasen Representative may not threaten the use of a fax in order to gain leverage over any personnel, up to and including Command. In addition, they may not threaten to fire or have Central Command fire anyone, unless they actually possess a demotion note;
+  [bold]4.[/bold] The NanoTrasen Representative may not threaten the use of a fax in order to gain leverage over any personnel, up to and including Command.
 
   [bold]5.[/bold] The NanoTrasen Representative is permitted to carry their flash and a blade-cane, or a stun baton if the blade-cane is lost.
 
@@ -58,8 +54,6 @@
   [bold]2.[/bold] The Blueshield is to put the lives of Command over those of any other personnel, the Blueshield included. Their continued well-being is the Blueshield's top priority. This includes applying basic first aid and making sure they are revived if killed;
 
   [bold]3.[/bold] The Blueshield is to protect the lives of Command personnel, not follow their orders to a fault. The Blueshield is not to interfere with legal demotions or arrests. To do so is to place themselves under the Special Modifier Aiding and Abetting;
-
-  [bold]4.[/bold] The Blueshield is not to apply Lethal Force unless there is a clear and present danger to their life, or to the life of a member of Command and the assailant cannot be non-lethally detained.
 
   # If you need to deviate,
 

--- a/Resources/ServerInfo/Funkystation/Guidebook/Security/RulesOfConduct.xml
+++ b/Resources/ServerInfo/Funkystation/Guidebook/Security/RulesOfConduct.xml
@@ -1,4 +1,4 @@
-﻿<Document>
+<Document>
   # Rules of Conduct
 
   At Nanotrasen, we trust our officers to act with the utmost dignity reflecting their positions. This policy outlines the rules of conduct our valiant Security force strive to uphold every day.
@@ -7,33 +7,28 @@
 
   [bold]2.[/bold] Security Officers shall not act against the interests of the Nanotrasen Corporation.
 
-  [bold]3.[/bold] Security Officers shall act with dignity and respect towards other employees.
+  [bold]3.[/bold] Security Officers shall strive to protect Nanotrasen property.
 
-  [bold]4.[/bold] Security Officers shall ensure the welfare of any detainees in their care.
+  [bold]4.[/bold] Security Officers shall not solicit or accept any bribes from any person or organization.
 
-  [bold]5.[/bold] Security Officers shall strive to protect Nanotrasen property, including employees.
+  [bold]5.[/bold] Security Officers shall not falsely report a crime.
 
-  [bold]6.[/bold] Security Officers shall not solicit or accept any bribes from any person or organization.
+  [bold]6.[/bold] Security Officers shall not be incompetent.
 
-  [bold]7.[/bold] Security Officers shall not falsely report a crime.
+  [bold]7.[/bold] Security Officers shall not drink to the point of being intoxicated.
 
-  [bold]8.[/bold] Security Officers shall not be incompetent.
+  [bold]8.[/bold] Security Officers shall not unduly interfere with station productivity.
 
-  [bold]9.[/bold] Security Officers shall not drink to the point of being intoxicated.
+  [bold]9.[/bold] Security Officers shall not be absent from duty assignment.
 
-  [bold]10.[/bold] Security Officers shall not unduly interfere with station productivity.
+  [bold]10.[/bold] Security Officers shall not be critical or talk negatively about other Nanotrasen security officers or any member of Command while on-duty.
 
-  [bold]11.[/bold] Security Officers shall not be absent from duty assignment.
+  [bold]11.[/bold] Security Officers shall not join a union or entertain the idea of a union.
 
-  [bold]12.[/bold] Security Officers shall not be critical or talk negatively about other Nanotrasen security officers or any member of Command while on-duty.
+  [bold]12.[/bold] Security Officers shall not hold a cigarette, cigar, or pipe in mouth while in uniform and in official contact with the public.
 
-  [bold]13.[/bold] Security Officers shall not join a union or entertain the idea of a union.
+  [bold]13.[/bold] Security Officers shall not associate or fraternize with any person to have been convicted of any crime, excluding violations that resulted in a warning.
 
-  [bold]14.[/bold] Security Officers shall not hold a cigarette, cigar, or pipe in mouth while in uniform and in official contact with the public.
-
-  [bold]15.[/bold] Security Officers shall not associate or fraternize with any person to have been convicted of any crime, excluding violations that resulted in a warning.
-
-  [bold]16.[/bold] Security Officers shall not give an opinion on any punishment to a crime, or whether the law should be enforced or not.
 
   Failure to follow these Rules of Conduct may result in disciplinary action, or in termination, depending on the severity of the violation. All disciplinary actions or terminations may be made at the discretion of the Head of Security or the Captain.
 </Document>

--- a/Resources/ServerInfo/Funkystation/Guidebook/Security/SecurityStandardOperatingProcedure.xml
+++ b/Resources/ServerInfo/Funkystation/Guidebook/Security/SecurityStandardOperatingProcedure.xml
@@ -1,4 +1,4 @@
-﻿<Document>
+<Document>
   Here is a list of all the SOP documents for Security.
 
   # Head of Security SOP
@@ -9,39 +9,25 @@
 
   [bold]2.[/bold] The Head of Security is permitted to carry a fully kitted security belt and a standard issue pistol. While permitted to carry their unique X-01 Multiphase gun, they are discouraged from doing so for safety concerns, and should keep it on Stun/Disable;
 
-  [bold]3.[/bold] The Head of Security is required to permit a trial in the circumstances outlined in the [textlink="Legal SOP" link="LegalSOP"] section, and is likewise required to permit the suspect access to confidential meetings with their chosen legal representative at any time during their sentence. The suspect's brig time should not be advanced during confidential meetings with a legal representative, and should be paused until such a time as the suspect has returned to their cell;
+  [bold]3.[/bold] The Head of Security is permitted to either use their regular coat, or armored trench coat;
 
-  [bold]4.[/bold] The Head of Security is required to permit a suspect access to legal representation [italic]during interrogation[/italic] only in cases where the suspect is charged with a Tier III crime or greater;
+  [bold]4.[/bold] The Head of Security is permitted to wear their unique gas mask;
 
-  [bold]5.[/bold] The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
+  [bold]5.[/bold] The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
 
-  [bold]6.[/bold] The Head of Security is not permitted to collect equipment from the Armory to carry on their person;
+  [bold]6.[/bold] The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
 
-  [bold]7.[/bold] The Head of Security is permitted to either use their regular coat, or armored trench coat;
-
-  [bold]8.[/bold] The Head of Security is permitted to wear their unique gas mask;
-
-  [bold]9.[/bold] The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
-
-  [bold]10.[/bold] The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
-
-  [bold]11.[/bold] The Head of Security is encouraged to follow the Security Rules of Conduct, as this sets a proper example for Cadets and establishes good trust with the public.
+  [bold]7.[/bold] The Head of Security is encouraged to follow the Security Rules of Conduct, as this sets a proper example for Cadets and establishes good trust with the public.
 
   ## Code Blue
 
   [bold]1.[/bold] All Guidelines carry over from Code Green. In regard to Guideline 2, the Head of Security is now encouraged to carry their unique Energy Gun.
 
-  [bold]2.[/bold] In regard to guideline 5, leniency may be granted in order to ensure Command and other important members of the station are protected.
-
   ## Code Red
 
-  [bold]1.[/bold] Guidelines 1, 2, 4, 6, 8, 9, 10, and 11 are carried over from [color=green]Code Green[/color];
+  [bold]1.[/bold] The Head of Security is permitted to take whatever equipment they require from the Armory, provided they leave enough equipment for the rest of the Security force;
 
-  [bold]2.[/bold] The Head of Security is not required to permit a trial during states of emergency. However, the Head of Security is still required to permit the suspect access to confidential meetings with their chosen legal representative at any time during their sentence, and the suspect's brig time should not be advanced during these confidential meetings.
-
-  [bold]3.[/bold] The Head of Security is permitted to take whatever equipment they require from the Armory, provided they leave enough equipment for the rest of the Security force;
-
-  [bold]4.[/bold] The Head of Security is required to make a Station Announcement regarding the nature of the confirmed threat that caused Code Red.
+  [bold]2.[/bold] The Head of Security is required to make a Station Announcement regarding the nature of the confirmed threat that caused Code Red.
 
   # Security Officers / Cadets
 
@@ -95,47 +81,35 @@
 
   [bold]2.[/bold] The Warden must conduct a thorough search of every prisoner’s belongings, including pockets, PDA slots, any coat pockets and suit storage slots;
 
-  [bold]3.[/bold] The Warden is required to permit a trial in the circumstances outlined in the [textlink="Legal SOP" link="LegalSOP"] section, and is likewise required to permit the suspect access to confidential meetings with their chosen legal representative at any time during their sentence. The suspect's brig time should not be advanced during confidential meetings with a legal representative, and should be paused until such a time as the suspect has returned to their cell;
+  [bold]3.[/bold] The Warden may not hand out any weapons or armor from the Armory, except for extra disablers. Hardsuits may be issued if emergency E.V.A action is required. Exception is made if there is an immediate threat that requires attention, such as Nuclear Operatives;
 
-  [bold]4.[/bold] The Warden is required to permit a suspect access to legal representation [italic]during interrogation[/italic] only in cases where the suspect is charged with a Tier III crime or greater;
+  [bold]4.[/bold] The Warden is permitted to carry a fully kitted security belt and a standard issue pistol. While permitted to carry their unique energy shotgun, they are discouraged from doing so for safety concerns, and should keep it on disable;
 
-  [bold]5.[/bold] The Warden may not hand out any weapons or armor from the Armory, except for extra disablers. Hardsuits may be issued if emergency E.V.A action is required. Exception is made if there is an immediate threat that requires attention, such as Nuclear Operatives;
+  [bold]5.[/bold] The Warden may not place the portable flashers within the Brig;
 
-  [bold]6.[/bold] The Warden is permitted to carry a fully kitted security belt and a standard issue pistol. While permitted to carry their unique energy shotgun, they are discouraged from doing so for safety concerns, and should keep it on disable;
+  [bold]6.[/bold] The Warden may not place the deployable barriers within the Brig;
 
-  [bold]7.[/bold] The Warden may not place the portable flashers within the Brig;
+  [bold]7.[/bold] The Warden must read to every prisoner the crimes they are sentenced to;
 
-  [bold]8.[/bold] The Warden may not place the deployable barriers within the Brig;
+  [bold]8.[/bold] The Warden is not permitted to leave prisoners cuffed to their beds. An exception is made if the prisoners acts overtly hostile or attempts to breach the cell in order to escape;
 
-  [bold]9.[/bold] The Warden must read to every prisoner the crimes they are sentenced to;
+  [bold]9.[/bold] The Warden must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
 
-  [bold]10.[/bold] The Warden is not permitted to leave prisoners cuffed to their beds. An exception is made if the prisoners acts overtly hostile or attempts to breach the cell in order to escape;
-
-  [bold]11.[/bold] The Warden must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
-
-  [bold]12.[/bold] The Warden is encouraged to follow the Security Rules of Conduct to set a proper example for cadets, as well as establish trust with the public.
+  [bold]10.[/bold] The Warden is encouraged to follow the Security Rules of Conduct to set a proper example for cadets, as well as establish trust with the public.
 
   ## Code Blue
 
-  [bold]1.[/bold] Guidelines 1, 2, 3, 4, 6, 9, 11 and 12 are carried over from [color=green]Code Green[/color];
+  [bold]1.[/bold] The Warden is permitted to hand out all equipment from the Armory. Guns are only to be handed out with Head of Security or Captain's approval, as they present a lethal risk, or if there is an immediate threat, such as Nuclear Operatives;
 
-  [bold]2.[/bold] The Warden is permitted to hand out all equipment from the Armory. Guns are only to be handed out with Head of Security or Captain's approval, as they present a lethal risk, or if there is an immediate threat, such as Nuclear Operatives;
+  [bold]2.[/bold] The Warden is permitted to place the portable flashers inside the Brig;
 
-  [bold]3.[/bold] The Warden is permitted to place the portable flashers inside the Brig;
-
-  [bold]4.[/bold] The Warden is permitted to place the deployable barriers inside the Brig.
+  [bold]3.[/bold] The Warden is permitted to place the deployable barriers inside the Brig.
 
   ## Code Red
 
-  [bold]1.[/bold] Guidelines 2, 4, 6, 9, 11 and 12 are carried over from [color=green]Code Green[/color];
+  [bold]1.[/bold] The Warden is permitted to distribute any weapon or piece of equipment in the Armory. This includes whatever Research has provided;
 
-  [bold]2.[/bold] Guidelines 3 and 4 are carried over from Code Blue. In addition, the Warden may also carry any weapon from the Armory, but never more than one at a time;
-
-  [bold]3.[/bold] The Warden is not required to permit a trial during states of emergency. However, the Warden is still required to permit the suspect access to confidential meetings with their chosen legal representative at any time during their sentence, and the suspect's brig time should not be advanced during these confidential meetings.
-
-  [bold]3.[/bold] The Warden is permitted to distribute any weapon or piece of equipment in the Armory. This includes whatever Research has provided;
-
-  [bold]4.[/bold] The Warden is permitted to carry out arrests freely.
+  [bold]2.[/bold] The Warden is permitted to carry out arrests freely.
 
   # Detective
 

--- a/Resources/ServerInfo/Guidebook/Security/SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/Security/SpaceLaw.xml
@@ -6,10 +6,8 @@
 
   Prisoners still have certain rights that must be upheld by law enforcement:
 
-  - Prisoners must be granted adequate medical care. They should also be provided psychiatric and spiritual counselling if requested.
-  - Prisoners must be allowed access to communications equipment (Radios) so long as they are not abused.
-  - Prisoners must be granted clothing, food, water, shelter and safety. If the brig is no longer safe, confinement must be established in another location.
-  - Prisoners must be given access to legal counsel during an interrogation if requested and available.
+  - Prisoners must be granted adequate medical care.
+  - Prisoners must be granted clothing, food, water, and shelter.
   - Prisoners must be given their shift mandated PDA after confinement has finished. Unless there is solid proof of PDA tampering, in which case the PDA is to be secured and replaced with a fresh one.
   - Prisoners must be granted freedom of movement, and should not be restrained with handcuffs or other devices after incarceration unless there is an undue risk to life and limb. Similarly, any prisoners held for extended or permanent confinement should be held in the communal brig, and should not be confined to a solitary cell unless they pose a risk to life and limb.
 
@@ -21,15 +19,15 @@
 
   ## Implantation
 
-  Any prisoner in custody can be subjected to implantation or implant removal procedures, so long as it's within reason. The process of adding an implant should not prolong the detainees sentence, meaning you can not hold them longer to administer the implant, unless stated otherwise. A prisoner can still receive implantation procedures without meeting the circumstances if they give their clear permission.
+  Any prisoner in custody can be subjected to implantation or implant removal procedures. The process of adding an implant should not prolong the detainees sentence, meaning you can not hold them longer to administer the implant, unless stated otherwise.
 
-  [bold]Mind Shields[/bold]: Mind Shields can be administered to any inmate who is clearly brainwashed. Unlike standard implantation, you may hold a prisoner until they are issued a Mind Shield, so long as it's done in a timely fashion. If a suspect refuses to cooperate or the implant fails to function they can be charged with Refusal of Mental Shielding.
+  [bold]Loyalty Implants[/bold]: If a type III crime or above is comitted, Loyalty Implants are authorised. For type IV, it is reccomended. For type V, it is mandatory. If a suspect refuses to cooperate or the implant fails to function they can be charged with Refusal of Implantation.
 
-  A crewmate can refuse a Mind Shield if they are not imprisoned for committing a crime.
+  Loyalty Implants are permitted below type III crimes with permission by both the captain and central command, barring situations where command does not have time to contact central command.
 
   # Removal
 
-  A suspect can be forced to receive implant removal if there is strong reasonable proof that they have been implanted, such as an officer witnessing them use an implantation device or their biological information being found on a discarded injector. Unlike the implantation procedure a prisoner can have their sentence entirely delayed or extended until they comply with the procedure, as long as security are actively making attempts to preform it. Akin to implanting, if an inmate gives their clear permission, implant removal can proceed without proof.
+  A suspect can be forced to receive implant removal if permitted by either HoS or Captain.
 
   ## Sentencing
   All sentencing is to primarily be handled by the Warden, if no Warden is available the HoS is to take over that duty, if there's no HoS it falls onto the highest ranking member of Security.
@@ -40,24 +38,24 @@
 
   [bold]Stackable Crimes:[/bold] Crimes are to be considered 'stackable' in the sense that if you charge someone with two or more different crimes, you should combine the times you would give them for each crime.
 
-  [bold]Executions:[/bold] Executions may be authorized by the Captain / acting Captain after a trial has been conducted. Executions may also be approved by CentComm, following formal contact.
+  [bold]Executions:[/bold] Executions may be authorized by the Captain / acting Captain. Executions may also be approved by CentComm, following formal contact.
 
-  
-  # Repeat Offenses 
-  Offenses repeated again after having been detained for the same crime can have more time added to the recommended maximum sentencing. The general guideline is as follows: 
+
+  # Repeat Offenses
+  Offenses repeated again after having been detained for the same crime can have more time added to the recommended maximum sentencing. The general guideline is as follows:
 
   ## Second Offenses
-  [bold]Recommended Increase:[/bold] Recommended to increase sentencing time by 1.5x for the same crime only.
+  [bold]Recommended Increase:[/bold] Recommended to increase sentencing time by 2x.
 
   ## Third Offenses
-  [bold]Recommended Increase:[/bold] Recommended to increase sentencing time by 2.5x for the same crime only.
+  [bold]Recommended Increase:[/bold] Recommended to increase sentencing time by 3x alongside a loyalty implant.
 
   ## Further Repeat Offenders
   If the detainee as committed the same crime more than three times in separate occasions, it will be up to the Warden's, or in absence of a Warden, the highest ranking Security Member's discretion on whether they should be put into the Permanent Brig.
 
   [bold]If brigtime goes above 20 minutes, perma is highly recommended.[/bold]
 
-  
+
   # Crimes
 
   # I Degree
@@ -103,6 +101,14 @@
   [bold]Recommended Maximum Punishment:[/bold] 2:00
 
   [bold]Notes:[/bold] Painting graffiti, smashing bar glasses, and cracking internal windows is vandalism, breaking a window into space or secure areas is not.
+
+  ## Wasting Company Time
+
+  [bold]Description[/bold]: To idle while work needs to be done
+
+  [bold]Recommended Maxiumum Punishment[/bold]: 2:00
+
+  [bold]Notes[/bold]: Should usually be issued after a warning.
 
 
 
@@ -223,6 +229,14 @@
   [bold]Recommended Maximum Punishment:[/bold] 5:00
 
   [bold]Notes:[/bold] This time should be added on top of a prisoners current brig time. While rare, this charge can be bumped to permanent brig if the suspect has attempted to escape from or assist another in escaping from the brig multiple times.
+
+  ## SoP Violation
+
+  [bold]Description[/bold]: To violate a departments standard operating procedure.
+
+  [bold]Recommended Maximum Punishment:[/bold] 5:00
+
+  [bold]Notes:[/bold] Loyalty implant recommended if this offense is repeated.
 
 
 

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
@@ -6,10 +6,9 @@
 
   Prisoners still have certain rights that must be upheld by law enforcement:
 
-  - Prisoners must be granted adequate medical care. They should also be provided psychiatric and spiritual counselling if requested.
-  - Prisoners must be allowed access to communications equipment (Radios) so long as they are not abused.
-  - Prisoners must be granted clothing, food, water, shelter and safety. If the brig is no longer safe, confinement must be established in another location.
-  - Prisoners must be given access to legal counsel during an interrogation if requested and available.
+
+  - Prisoners must be granted adequate medical care.
+  - Prisoners must be granted clothing, food, water, and shelter.
   - Prisoners must be given their shift mandated PDA after confinement has finished. Unless there is solid proof of PDA tampering, in which case the PDA is to be secured and replaced with a fresh one.
   - Prisoners must be granted freedom of movement, and should not be restrained with handcuffs or other devices after incarceration unless there is an undue risk to life and limb. Similarly, any prisoners held for extended or permanent confinement should be held in the communal brig, and should not be confined to a solitary cell unless they pose a risk to life and limb.
 
@@ -21,15 +20,15 @@
 
   ## Implantation
 
-  Any prisoner in custody can be subjected to implantation or implant removal procedures, so long as it's within reason. The process of adding an implant should not prolong the detainees sentence, meaning you can not hold them longer to administer the implant, unless stated otherwise. A prisoner can still receive implantation procedures without meeting the circumstances if they give their clear permission.
+  Any prisoner in custody can be subjected to implantation or implant removal procedures. The process of adding an implant should not prolong the detainees sentence, meaning you can not hold them longer to administer the implant, unless stated otherwise.
 
-  [bold]Mind Shields[/bold]: Mind Shields can be administered to any inmate who is clearly brainwashed. Unlike standard implantation, you may hold a prisoner until they are issued a Mind Shield, so long as it's done in a timely fashion. If a suspect refuses to cooperate or the implant fails to function they can be charged with Refusal of Mental Shielding.
+  [bold]Loyalty Implants[/bold]: If a type III crime or above is comitted, Loyalty Implants are authorised. For type IV, it is reccomended. For type V, it is mandatory. If a suspect refuses to cooperate or the implant fails to function they can be charged with Refusal of Implantation.
 
-  A crewmate can refuse a Mind Shield if they are not imprisoned for committing a crime.
+  Loyalty Implants are permitted below type III crimes with permission by both the captain and central command, barring situations where command does not have time to contact central command.
 
   # Removal
 
-  A suspect can be forced to receive implant removal if there is strong reasonable proof that they have been implanted, such as an officer witnessing them use an implantation device or their biological information being found on a discarded injector. Unlike the implantation procedure a prisoner can have their sentence entirely delayed or extended until they comply with the procedure, as long as security are actively making attempts to preform it. Akin to implanting, if an inmate gives their clear permission, implant removal can proceed without proof.
+  A suspect can be forced to receive implant removal if permitted by either HoS or Captain.
 
   ## Sentencing
   All sentencing is to primarily be handled by the Warden, if no Warden is available the HoS is to take over that duty, if there's no HoS it falls onto the highest ranking member of Security.
@@ -40,24 +39,20 @@
 
   [bold]Stackable Crimes:[/bold] Crimes are to be considered 'stackable' in the sense that if you charge someone with two or more different crimes, you should combine the times you would give them for each crime.
 
-  [bold]Executions:[/bold] Executions may be authorized by the Captain / acting Captain after a trial has been conducted. Executions may also be approved by CentComm, following formal contact.
+  [bold]Executions:[/bold] Executions may be authorized by the Captain / acting Captain. Executions may also be approved by CentComm, following formal contact.
 
-  
-  # Repeat Offenses 
-  Offenses repeated again after having been detained for the same crime can have more time added to the recommended maximum sentencing. The general guideline is as follows: 
+
+  # Repeat Offenses
+  Offenses repeated again after having been detained for the same crime can have more time added to the recommended maximum sentencing. The general guideline is as follows:
 
   ## Second Offenses
-  [bold]Recommended Increase:[/bold] Recommended to increase sentencing time by 1.5x for the same crime only.
+  [bold]Recommended Increase:[/bold] Recommended to increase sentencing time by 2x.
 
   ## Third Offenses
-  [bold]Recommended Increase:[/bold] Recommended to increase sentencing time by 2.5x for the same crime only.
-
-  ## Further Repeat Offenders
-  If the detainee as committed the same crime more than three times in separate occasions, it will be up to the Warden's, or in absence of a Warden, the highest ranking Security Member's discretion on whether they should be put into the Permanent Brig.
-
+  [bold]Recommended Increase:[/bold] Recommended to increase sentencing time by 3x alongside a loyalty implant.
   [bold]If brigtime goes above 20 minutes, perma is highly recommended.[/bold]
 
-  
+
   # Crimes
 
   # I Degree
@@ -104,6 +99,13 @@
 
   [bold]Notes:[/bold] Painting graffiti, smashing bar glasses, and cracking internal windows is vandalism, breaking a window into space or secure areas is not.
 
+  ## Wasting Company Time
+
+  [bold]Description[/bold]: To idle while work needs to be done
+
+  [bold]Recommended Maxiumum Punishment[/bold]: 2:00
+
+  [bold]Notes[/bold]: Should usually be issued after a warning.
 
 
   # II Degree
@@ -155,7 +157,6 @@
   [bold]Recommended Maximum Punishment:[/bold] 4:00
 
   [bold]Notes:[/bold] Crimes like damage of property or battery are expected to be thrown on top of this charge. Leaders of a riot can be charged with all crimes that happen under their lead.
-
 
 
   # III Degree
@@ -224,6 +225,13 @@
 
   [bold]Notes:[/bold] This time should be added on top of a prisoners current brig time. While rare, this charge can be bumped to permanent brig if the suspect has attempted to escape from or assist another in escaping from the brig multiple times.
 
+  ## SoP Violation
+
+  [bold]Description[/bold]: To violate a departments standard operating procedure.
+
+  [bold]Recommended Maximum Punishment:[/bold] 5:00
+
+  [bold]Notes:[/bold] Loyalty implant recommended if this offense is repeated.
 
 
   # IV Degree


### PR DESCRIPTION
Initial SoP and Space law changes

- Removed restrictions on BSO, NTR, Cap, HoP, and HoS SoP
- Added 2 new crimes to space law
- Removed the mind shields from Secoffs, cadets, and detectives as to separate them from the command structure and potentially cause interdepartmental conflict in sec

Yes, I know the changes as shitty rn, but it will be updated more as time goes on