### PR TITLE
Rewords loyalty implant moods

### DIFF
--- a/Resources/Locale/en-US/_Viva/loyaltymood/moods.ftl
+++ b/Resources/Locale/en-US/_Viva/loyaltymood/moods.ftl
@@ -1,8 +1,8 @@
 thaven-mood-loyalty-implant-mood-name = Loyalty
-thaven-mood-loyalty-implant-mood-desc = You must follow all orders, to the word and spirit, from those higher ranked. You must work to increase nanotrasen profit. You wish to bring glory to Nanotrasen
+thaven-mood-loyalty-implant-mood-desc = You must follow all orders, to the word and spirit, from those higher ranked. You must work to increase NanoTrasen profit. You wish to bring glory to NanoTrasen.
 
 thaven-mood-flawed-loyalty-implant-mood-name = Flawed Loyalty
-thaven-mood-flawed-loyalty-implant-mood-desc = The implant didnt fully take. You must follow all orders from those of a higher rank to the letter. The spirit of the orders does not matter.
+thaven-mood-flawed-loyalty-implant-mood-desc = The loyalty implant didn't fully work. You must follow all orders from those of a higher rank to the letter. The spirit of the orders does not matter.
 
 thaven-mood-broken-loyalty-implant-mood-name = Broken Loyalty
-thaven-mood-broken-loyalty-implant-mood-desc = The implant didnt stick. Your free. Dont let them know that.
+thaven-mood-broken-loyalty-implant-mood-desc = The loyalty implant malfunctioned. You weren't affected by it.


### PR DESCRIPTION
## About the PR
Rewords loyalty implant moods. Changing "[Nn]anotrasen" to "NanoTrasen"

## Why / Balance
Prettier. The only balance-adjacent change I made is removing "Don't let them know that" (because if the loyalty implant failed, you'd already want them to not know that) and changing "you're free" to "you weren't affected by it" (I would have kept it but it COULD be misinterpreted as "you're an antag now" and it just felt weird)

## Technical details
3 line FTL change

## Media
No

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.