### PR TITLE
Add t-ray scanner to Atmos borg module

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -311,6 +311,7 @@
     items:
     - RPDRecharging
     - HolofanProjectorRecharging
+    - trayScanner
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: atmos-module }
 


### PR DESCRIPTION
Does exactly what it says on the tin.
You currently have to keep swapping to wire module to see under tiles, which sucks