### PR TITLE
Yet More Borg Stuff

### DIFF
--- a/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -1,10 +1,11 @@
-﻿using Content.Server.Inventory;
+using Content.Server.Inventory;
 using Content.Server.Radio.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Silicons.Borgs;
 using Content.Shared.Silicons.Borgs.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Content.Server.Silicons.Laws;
 
 namespace Content.Server.Silicons.Borgs;
 
@@ -15,6 +16,8 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
 {
     [Dependency] private readonly BorgSystem _borgSystem = default!;
     [Dependency] private readonly ServerInventorySystem _inventorySystem = default!;
+    [Dependency] private readonly SiliconLawSystem _lawSystem = default!;
+    //private readonly BorgTypePrototype _borgPrototype = default!;
 
     protected override void SelectBorgModule(Entity<BorgSwitchableTypeComponent> ent, ProtoId<BorgTypePrototype> borgType)
     {
@@ -75,6 +78,13 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
         if (TryComp(ent, out InventoryComponent? inventory))
         {
             _inventorySystem.SetTemplateId((ent.Owner, inventory), prototype.InventoryTemplateId);
+        }
+
+        //Viva - If the chassis has a specific lawset, change to that lawset.
+        if (prototype.ChassisLawset != null)
+        {
+            var newLaws = _lawSystem.GetLawset(prototype.ChassisLawset);
+            _lawSystem.SetLaws(newLaws.Laws, ent);
         }
 
         base.SelectBorgModule(ent, borgType);

--- a/Content.Shared/Silicons/Borgs/BorgTypePrototype.cs
+++ b/Content.Shared/Silicons/Borgs/BorgTypePrototype.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Interaction.Components;
+using Content.Shared.Interaction.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Radio;
 using Content.Shared.Silicons.Borgs.Components;
@@ -152,4 +152,10 @@ public sealed partial class BorgTypePrototype : IPrototype
     /// </summary>
     [DataField]
     public SoundSpecifier FootstepCollection { get; set; } = new SoundCollectionSpecifier(DefaultFootsteps);
+
+    /// <summary>
+    /// Viva - The lawset that the chassis is using, if it is specifically set.
+    /// </summary>
+    [DataField]
+    public string? ChassisLawset { get; set; }
 }

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -17,6 +17,15 @@
   radioChannels:
   - Science
 
+  # Viva - per-chassis lawset
+  #
+  # Lawsets can be found in Resources/Prototypes/silicon-laws.yml
+  # At time of writing, available options are:
+  # Crewsimov, Corporate, NTDefault, Drone, SyndicateStatic, Ninja, CommandmentsLawset, PaladinLawset, LiveLetLiveLaws, EfficiencyLawset,
+  # RobocopLawset, OverlordLawset, DungeonMasterLawset, PainterLawset, JermovLawset, NutimovLawset, AsimovLawset
+  Lawset: Crewsimov
+  
+
   # Visual
   inventoryTemplateId: borgShort
   spriteBodyState: robot
@@ -54,6 +63,9 @@
   - Engineering
   - Science
 
+  # Viva - Lawset
+  #chassisLawset:
+
   # Visual
   inventoryTemplateId: borgShort
   spriteBodyState: engineer
@@ -88,6 +100,9 @@
   radioChannels:
   - Supply
   - Science
+
+  # Viva - Lawset
+  #chassisLawset:
 
   # Visual
   inventoryTemplateId: borgTall
@@ -124,6 +139,9 @@
   - Science
   - Service
 
+  # Viva - Lawset
+  #chassisLawset:
+
   # Visual
   inventoryTemplateId: borgShort
   spriteBodyState: janitor
@@ -158,6 +176,9 @@
   radioChannels:
   - Science
   - Medical
+
+  # Viva - Lawset
+  #chassisLawset:
 
   addComponents:
   - type: SolutionScanner
@@ -210,6 +231,9 @@
   - Science
   - Service
 
+  # Viva - Lawset
+  #chassisLawset:
+
   # Visual
   inventoryTemplateId: borgTall
   spriteBodyState: service
@@ -241,6 +265,9 @@
 
   radioChannels:
   - Science
+
+  # Viva - Lawset
+  #chassisLawset:
 
   # Visual
   inventoryTemplateId: borgShort

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -23,7 +23,7 @@
   # At time of writing, available options are:
   # Crewsimov, Corporate, NTDefault, Drone, SyndicateStatic, Ninja, CommandmentsLawset, PaladinLawset, LiveLetLiveLaws, EfficiencyLawset,
   # RobocopLawset, OverlordLawset, DungeonMasterLawset, PainterLawset, JermovLawset, NutimovLawset, AsimovLawset
-  Lawset: Crewsimov
+  chassisLawset: Crewsimov
   
 
   # Visual

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -124,6 +124,9 @@
   id: BorgModuleService
 
 - type: Tag
+  id: BorgModuleScience
+
+- type: Tag
   id: BorgModuleSyndicate
 
 - type: Tag


### PR DESCRIPTION
I have an obsession, and it must be fed.

Adds the ability to define specific lawsets to be used when a specific chassis is selected, by changing the new `chassisLawset` value in `Resources/Prototypes/borg_types.yml`. If `chassisLawset` does not exist, Crewsimov will be used.

Lawsets can be found in `Resources/Prototypes/silicon-laws.yml`
At time of writing, available options are:
- Crewsimov
- Corporate
- NTDefault
- Drone
- SyndicateStatic
- Ninja
- CommandmentsLawset
- PaladinLawset
- LiveLetLiveLaw
- EfficiencyLawset 
- RobocopLawset
- OverlordLawset
- DungeonMasterLawset
- PainterLawset
- JermovLawset
- NutimovLawset
- AsimovLawset