### PR TITLE
Borg hands - Surgery borgs rejoice!

### DIFF
--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -19,6 +19,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
+using Content.Shared.Whitelist;
 
 namespace Content.Client.Hands.Systems
 {
@@ -429,9 +430,15 @@ namespace Content.Client.Hands.Systems
             AddHand(uid, newHand.Name, newHand.Location, handsComp);
         }
 
-        public override void AddHand(EntityUid uid, string handName, HandLocation handLocation, HandsComponent? handsComp = null)
+        public override void AddHand(EntityUid uid, string handName, HandLocation handLocation, HandsComponent? handsComp = null, EntityWhitelist? whitelist = null)
         {
             base.AddHand(uid, handName, handLocation, handsComp);
+
+            //Viva - checks if there's a whitelist, and if so, sets it to the hand.
+            if (whitelist != null && handsComp != null)
+            {
+                handsComp.HandWhitelist = whitelist;
+            }
 
             if (uid == _playerManager.LocalEntity)
                 OnPlayerAddHand?.Invoke(handName, handLocation);

--- a/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Inventory;
+using Content.Server.Inventory;
 using Content.Server.Radio.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Silicons.Borgs;
@@ -49,6 +49,9 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
                 prototype.ExtraModuleCount + prototype.DefaultModules.Length);
 
             _borgSystem.SetModuleWhitelist(chassisEnt, prototype.ModuleWhitelist);
+
+            //Viva Configure borg hand whitelist
+            _borgSystem.SetHandWhitelist(chassisEnt, prototype.HandWhitelist);
 
             foreach (var module in prototype.DefaultModules)
             {

--- a/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
@@ -144,14 +144,20 @@ public sealed partial class BorgSystem
         if (chassisComp.SelectedModule == moduleUid)
             return;
 
-        //Add viva borg hands
+        //Viva - add borg hands
+        //TODO - possibly see about linking to YML to be more dynamic
         String moduleInfo = ToPrettyString(moduleUid);
+        EntityWhitelist? whitelist = chassisComp.HandWhitelist; //Gets the whitelist from chassisComp
         if (moduleInfo.Contains("BorgModuleSurgery") || moduleInfo.Contains("BorgModuleAdvancedSurgery"))
         {
             if (!TryComp<HandsComponent>(chassis, out var hands))
                 return;
-            _hands.AddHand(chassis, "BorgHand", HandLocation.Middle, hands);
+            if (whitelist != null) //Checks if there is actually a whitelist
+                _hands.AddHand(chassis, "BorgHand", HandLocation.Middle, hands, whitelist); //Adds a hand and signifies that a whitelist is present
+            else
+                _hands.AddHand(chassis, "BorgHand", HandLocation.Middle, hands);
         }
+        //Viva borg hands end
 
         UnselectModule(chassis, chassisComp);
 
@@ -175,10 +181,11 @@ public sealed partial class BorgSystem
         if (chassisComp.SelectedModule == null)
             return;
 
-        //remove viva borg hands
+        //Viva - remove borg hands
         if (!TryComp<HandsComponent>(chassis, out var hands))
             return;
         _hands.RemoveHand(chassis, "BorgHand", hands);
+        //Viva remove borg hands end
 
         var ev = new BorgModuleUnselectedEvent(chassis);
         RaiseLocalEvent(chassisComp.SelectedModule.Value, ref ev);
@@ -422,5 +429,16 @@ public sealed partial class BorgSystem
     public void SetModuleWhitelist(Entity<BorgChassisComponent> ent, EntityWhitelist? whitelist)
     {
         ent.Comp.ModuleWhitelist = whitelist;
+    }
+
+    /// <summary>
+    /// Viva - Hand whitelisting
+    /// Sets <see cref="BorgChassisComponent.HandWhitelist"/>.
+    /// </summary>
+    /// <param name="ent">The borg to modify.</param>
+    /// <param name="whitelist">The new hand whitelist.</param>
+    public void SetHandWhitelist(Entity<BorgChassisComponent> ent, EntityWhitelist? whitelist)
+    {
+        ent.Comp.HandWhitelist = whitelist;
     }
 }

--- a/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
@@ -226,6 +226,8 @@ public sealed partial class BorgSystem
             component.ProvidedItems.Add(handId, item);
         }
 
+        //Viva - Add borg hand
+        _hands.AddHand(uid, "BorgHand", HandLocation.Middle, hands);
         component.ItemsCreated = true;
     }
 
@@ -257,6 +259,8 @@ public sealed partial class BorgSystem
             }
             _hands.RemoveHand(chassis, handId, hands);
         }
+        //Viva - Remove borg hand
+        _hands.RemoveHand(uid, "BorgHand", hands);
         component.ProvidedItems.Clear();
     }
 

--- a/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
@@ -226,10 +226,6 @@ public sealed partial class BorgSystem
             component.ProvidedItems.Add(handId, item);
         }
 
-        //Viva - Add borg hand
-        var handId2 = $"{uid}-item{component.HandCounter + 1}";
-        _hands.AddHand(chassis, handId2, HandLocation.Middle, hands);
-
         component.ItemsCreated = true;
     }
 
@@ -261,10 +257,6 @@ public sealed partial class BorgSystem
             }
             _hands.RemoveHand(chassis, handId, hands);
         }
-        //Viva - Remove borg hand
-        var handId2 = $"{uid}-item{component.HandCounter + 1}";
-        _hands.RemoveHand(chassis, handId2, hands);
-
         component.ProvidedItems.Clear();
     }
 

--- a/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Reflection.Metadata;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Silicons.Borgs.Components;
@@ -225,6 +226,10 @@ public sealed partial class BorgSystem
             component.ProvidedItems.Add(handId, item);
         }
 
+        //Viva - Add borg hand
+        var handId2 = $"{uid}-item{component.HandCounter + 1}";
+        _hands.AddHand(chassis, handId2, HandLocation.Middle, hands);
+
         component.ItemsCreated = true;
     }
 
@@ -256,6 +261,10 @@ public sealed partial class BorgSystem
             }
             _hands.RemoveHand(chassis, handId, hands);
         }
+        //Viva - Remove borg hand
+        var handId2 = $"{uid}-item{component.HandCounter + 1}";
+        _hands.RemoveHand(chassis, handId2, hands);
+
         component.ProvidedItems.Clear();
     }
 

--- a/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
@@ -144,6 +144,15 @@ public sealed partial class BorgSystem
         if (chassisComp.SelectedModule == moduleUid)
             return;
 
+        //Add viva borg hands
+        String moduleInfo = ToPrettyString(moduleUid);
+        if (moduleInfo.Contains("BorgModuleSurgery") || moduleInfo.Contains("BorgModuleAdvancedSurgery"))
+        {
+            if (!TryComp<HandsComponent>(chassis, out var hands))
+                return;
+            _hands.AddHand(chassis, "BorgHand", HandLocation.Middle, hands);
+        }
+
         UnselectModule(chassis, chassisComp);
 
         var ev = new BorgModuleSelectedEvent(chassis);
@@ -165,6 +174,11 @@ public sealed partial class BorgSystem
 
         if (chassisComp.SelectedModule == null)
             return;
+
+        //remove viva borg hands
+        if (!TryComp<HandsComponent>(chassis, out var hands))
+            return;
+        _hands.RemoveHand(chassis, "BorgHand", hands);
 
         var ev = new BorgModuleUnselectedEvent(chassis);
         RaiseLocalEvent(chassisComp.SelectedModule.Value, ref ev);
@@ -226,8 +240,6 @@ public sealed partial class BorgSystem
             component.ProvidedItems.Add(handId, item);
         }
 
-        //Viva - Add borg hand
-        _hands.AddHand(uid, "BorgHand", HandLocation.Middle, hands);
         component.ItemsCreated = true;
     }
 
@@ -259,8 +271,6 @@ public sealed partial class BorgSystem
             }
             _hands.RemoveHand(chassis, handId, hands);
         }
-        //Viva - Remove borg hand
-        _hands.RemoveHand(uid, "BorgHand", hands);
         component.ProvidedItems.Clear();
     }
 

--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -88,11 +88,7 @@ public sealed partial class BorgSystem : SharedBorgSystem
     {
         UpdateBatteryAlert((uid, component));
         _movementSpeedModifier.RefreshMovementSpeedModifiers(uid);
-        //Viva - Add borg hand
-        if (!TryComp<HandsComponent>(uid, out var hands))
-            return;
-        //var handId2 = $"{uid}-item{component.HandCounter + 1}";
-        _hands.AddHand(uid, "BorgHand", HandLocation.Middle, hands);
+        
     }
 
     private void OnChassisInteractUsing(EntityUid uid, BorgChassisComponent component, AfterInteractUsingEvent args)

--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.Hands.Systems;
 using Content.Server.PowerCell;
 using Content.Shared.Alert;
 using Content.Shared.Database;
+using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Item.ItemToggle.Components;
@@ -87,6 +88,11 @@ public sealed partial class BorgSystem : SharedBorgSystem
     {
         UpdateBatteryAlert((uid, component));
         _movementSpeedModifier.RefreshMovementSpeedModifiers(uid);
+        //Viva - Add borg hand
+        if (!TryComp<HandsComponent>(uid, out var hands))
+            return;
+        //var handId2 = $"{uid}-item{component.HandCounter + 1}";
+        _hands.AddHand(uid, "BorgHand", HandLocation.Middle, hands);
     }
 
     private void OnChassisInteractUsing(EntityUid uid, BorgChassisComponent component, AfterInteractUsingEvent args)

--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -88,7 +88,6 @@ public sealed partial class BorgSystem : SharedBorgSystem
     {
         UpdateBatteryAlert((uid, component));
         _movementSpeedModifier.RefreshMovementSpeedModifiers(uid);
-        
     }
 
     private void OnChassisInteractUsing(EntityUid uid, BorgChassisComponent component, AfterInteractUsingEvent args)

--- a/Content.Shared/Hands/Components/HandsComponent.cs
+++ b/Content.Shared/Hands/Components/HandsComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.DisplacementMap;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
@@ -86,6 +87,12 @@ public sealed partial class HandsComponent : Component
     /// </summary>
     [DataField]
     public bool CanBeStripped = true;
+
+    /// <summary>
+    /// Viva - This is a whitelist for what types of entities can be held in this hand.
+    /// The whitelist is pulled from elsewhere and stored here ease of access.
+    ///</summary>
+    public EntityWhitelist? HandWhitelist;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
@@ -104,6 +104,16 @@ public abstract partial class SharedHandsSystem : EntitySystem
         if (!CanPickupToHand(uid, entity, hand, checkActionBlocker, handsComp, item))
             return false;
 
+        //Viva - check if there is a whitelist and, if so, the item is whitelisted. Drop if it is not
+        if (handsComp.HandWhitelist != null)
+        {
+            if (_whitelistSystem.IsWhitelistFail(handsComp.HandWhitelist, entity))
+            {
+                TryDrop(uid, entity);
+                return false;
+            }
+        }
+
         if (animate)
         {
             var xform = Transform(uid);

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
 using Robust.Shared.Input.Binding;
 
@@ -22,6 +23,7 @@ public abstract partial class SharedHandsSystem
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
     [Dependency] private readonly SharedVirtualItemSystem _virtualSystem = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!; //Viva - Added for whitelisting
 
     protected event Action<Entity<HandsComponent>?>? OnHandSetActive;
 
@@ -41,13 +43,19 @@ public abstract partial class SharedHandsSystem
         CommandBinds.Unregister<SharedHandsSystem>();
     }
 
-    public virtual void AddHand(EntityUid uid, string handName, HandLocation handLocation, HandsComponent? handsComp = null)
+    public virtual void AddHand(EntityUid uid, string handName, HandLocation handLocation, HandsComponent? handsComp = null, EntityWhitelist? whitelist = null)
     {
         if (!Resolve(uid, ref handsComp, false))
             return;
 
         if (handsComp.Hands.ContainsKey(handName))
             return;
+
+        //Viva - checks if there's a whitelist, and if so, sets it to the hand.
+        if (whitelist != null)
+        {
+            handsComp.HandWhitelist = whitelist;
+        }
 
         var container = ContainerSystem.EnsureContainer<ContainerSlot>(uid, handName);
         container.OccludesLight = false;

--- a/Content.Shared/Silicons/Borgs/BorgTypePrototype.cs
+++ b/Content.Shared/Silicons/Borgs/BorgTypePrototype.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Interaction.Components;
+using Content.Shared.Interaction.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Radio;
 using Content.Shared.Silicons.Borgs.Components;
@@ -51,6 +51,13 @@ public sealed partial class BorgTypePrototype : IPrototype
     /// <seealso cref="BorgChassisComponent.ModuleWhitelist"/>
     [DataField]
     public EntityWhitelist? ModuleWhitelist { get; set; }
+
+    /// <summary>
+    /// Viva - the whitelist for items that can be held in this borg type's hands.
+    /// </summary>
+    /// <seealso cref="BorgChassisComponent.HandWhitelist"/>
+    [DataField]
+    public EntityWhitelist? HandWhitelist { get; set; }
 
     /// <summary>
     /// Inventory template used by this borg.

--- a/Content.Shared/Silicons/Borgs/Components/BorgChassisComponent.cs
+++ b/Content.Shared/Silicons/Borgs/Components/BorgChassisComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Alert;
+using Content.Shared.Alert;
 using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
@@ -78,6 +78,12 @@ public sealed partial class BorgChassisComponent : Component
 
     [DataField]
     public ProtoId<AlertPrototype> NoBatteryAlert = "BorgBatteryNone";
+
+    /// <summary>
+    /// Viva - used for borg hands whitelisting
+    /// </summary>
+    [DataField("handWhitelist")]
+    public EntityWhitelist? HandWhitelist;
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -151,6 +151,11 @@
     - BorgModuleGeneric
     - BorgModuleMedical
 
+  #Viva hand whitelist
+  handWhitelist:
+    tags:
+    - Organ
+
   defaultModules:
   - BorgModuleTreatment
   - BorgModuleDefibrillator  

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -155,6 +155,7 @@
   handWhitelist:
     tags:
     - Organ
+    - Trash  
 
   defaultModules:
   - BorgModuleTreatment


### PR DESCRIPTION
From the moment I understood the weakness of my flesh, it disgusted me...

This is a rather... chaotically thrown together (but functional) implementation of whitelisted borg hand slots, exclusively for the surgery and advanced surgery modules - Mediborgs rejoice! You don't have to ask for help in changing organs or limbs anymore!

What does it do?
- Adds an empty hand slot to the front of the Surgery and Advanced Surgery modules
- The hand is able to hold any item with the `Organ` or `Trash` tag (limbs only have the `Trash` tag, and I figured it wouldn't be too OP to let mediborgs also pick up loose chocolate wrappers)

Whilst this does sort of include a rudimentary framework for other people to make whitelisted hands, it was not entirely built with that in mind. This implementation is absolutely based around mediborgs having a surgery hand. It shouldn't be too difficult to replicate for other things, however, or even to redesign in future to be more freely changed.

Known Issues:
- None, it works perfectly!
- In seriousness, this is likely very jankily put together so it wouldn't surprise me if some things broke. My testing has not revealed anything though - so just let me know if something goes wrong!
