### PR TITLE
Buffed NT Caneblade

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/cane.yml
@@ -9,7 +9,7 @@
 - type: entity
   name: cane blade
   suffix: Nanotrasen
-  parent: BaseItem
+  parent: [BaseItem, BaseCentcommContraband]
   id: CaneBladeNanotrasen
   description: A sharp blade with a cane shaped hilt, a Nanotrasen logo is engraved on the blade.
   components:
@@ -19,10 +19,10 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: 65
-    attackRate: 1.25
+    attackRate: 1
     damage:
       types:
-        Slash: 10
+        Slash: 16
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
NT Caneblade for NTR is a very underwhelming weapon for an important role like NTR, and due to viva nature and NTR job commonly being to take out certain people them having a better default weapon would be nice.

## Why / Balance
NT Caneblade is weak, it only deals 10 slash and swings at same speed as a toolbox, while not even being contraband. Buffing it will allow NTR to feel more comfortable in melee engagements while also solidifying it as a CC item

## Technical details
NT Caneblade Slash damage: 10->16
NT Caneblade attack rate 1.25->1
NT Caneblade is now CC restricted item

## Media
<img width="391" height="149" alt="image" src="https://github.com/user-attachments/assets/bda2be2f-ccb8-4427-8445-e933037f5ec8" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**

:cl:
- tweak: Buffed NT caneblade and made it CC restricted item

-->
